### PR TITLE
remove unnecessary frontend stylesheet

### DIFF
--- a/search-everything/search-everything.php
+++ b/search-everything/search-everything.php
@@ -905,12 +905,6 @@ function search_everything_callback() {
 	die();
 }
 
-function se_enqueue_styles() {
-	wp_enqueue_style('se-link-styles', SE_PLUGIN_URL . '/static/css/se-styles.css');
-}
-
-add_action('wp_enqueue_scripts', 'se_enqueue_styles');
-
 
 
 function se_post_publish_ping($post_id) {


### PR DESCRIPTION
There is no reason for this stylesheet to be present in the frontend. It is still included as an editor style at https://github.com/Zemanta/search-everything-wp-plugin/blob/master/search-everything/options.php#L47