### PR TITLE
bypass highlighting in dashboard searches

### DIFF
--- a/search-everything/search-everything.php
+++ b/search-everything/search-everything.php
@@ -817,7 +817,7 @@ class SearchEverything {
 		global $wpdb;
 		$s =  isset( $this->query_instance->query_vars['s'] ) ? $this->query_instance->query_vars['s'] : '';
 		// highlighting
-		if ( is_search() && $s != '' ) {
+		if ( !is_admin() && is_search() && $s != '' ) {
 			$highlight_color = $this->options['se_highlight_color'];
 			$highlight_style = $this->options['se_highlight_style'];
 			$search_terms = $this->se_get_search_terms();


### PR DESCRIPTION
Hi, quick fix here which prevents se_postfilter() running on the dashboard. The highlight markup was injected into the title as text in dashboard search results. Mentioned a couple of times on the .org plugin support page, hopefully this is a pretty uncontroversial pr.

https://wordpress.org/support/topic/getting-tag-on-backend-not-rendering-properly?replies=16
https://wordpress.org/support/topic/disable-highlighting-just-in-admin-area?replies=4