### PR TITLE
PHP7 Compatibility Fix

### DIFF
--- a/search-everything/options.php
+++ b/search-everything/options.php
@@ -5,8 +5,8 @@ Class se_admin {
 	function se_localization() {
 		load_plugin_textdomain('SearchEverything', false, dirname(plugin_basename( __FILE__ )) . '/lang/');
 	}
-	
-	function se_admin() {
+
+	function __construct() {
 		// Load language file
 		$locale = get_locale();
 		$meta = se_get_meta();
@@ -72,17 +72,17 @@ Class se_admin {
 			<input placeholder="Type search here" data-ajaxurl="<?php echo admin_url('admin-ajax.php'); ?>" type="search" placeholder="Search interesting stuff" name="se-metabox-text" id="se-metabox-text" value="" />
 			<a id="se-metabox-search">Search</a>
 		</div>
-		<?php	
+		<?php
 	}
 
 
 	function se_meta_box_search($post_id) {
 		// Bail if we're doing an auto save
 		if( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
-		
+
 		// if our nonce isn't there, or we can't verify it, bail
 		if( !isset( $_POST['meta_box_nonce'] ) || !wp_verify_nonce( $_POST['meta_box_nonce'], 'se-meta-box-nonce' ) ) return;
-		
+
 		// if our current user can't edit this post, bail
 		if( !current_user_can( 'edit_post' ) ) return;
 
@@ -113,11 +113,11 @@ Class se_admin {
 		}
 		return $errors;
 	}
-		  
+
 	//build admin interface
 	function se_option_page() {
 		global $wpdb, $table_prefix, $wp_version;
-		  
+
 		if($_POST) {
 			check_admin_referer('se-everything-nonce');
 			$errors = $this->se_validation(array(
@@ -137,7 +137,7 @@ Class se_admin {
 				return;
 			}
 		}
-		  
+
 		$new_options = array(
 			'se_exclude_categories'		=> (isset($_POST['exclude_categories']) && !empty($_POST['exclude_categories'])) ? $_POST['exclude_categories'] : '',
 			'se_exclude_categories_list'		=> (isset($_POST['exclude_categories_list']) && !empty($_POST['exclude_categories_list'])) ? $_POST['exclude_categories_list'] : '',
@@ -258,7 +258,7 @@ function se_api($arguments)
 	$meta = se_get_meta();
 
 	$api_key = $meta['api_key'] ? $meta['api_key'] : '';
-		  
+
 	$arguments = array_merge($arguments, array(
 		'api_key'=> $api_key
 	));

--- a/search-everything/search-everything.php
+++ b/search-everything/search-everything.php
@@ -48,7 +48,7 @@ add_action('wp_loaded','se_initialize_plugin');
 
 function se_initialize_plugin() {
 	$SE = new SearchEverything();
-	
+
 	//add filters based upon option settings
 	//include_once(SE_PLUGIN_DIR . '/zemanta/zemanta.php');
 	//$se_zemanta = new SEZemanta();
@@ -76,7 +76,7 @@ function se_global_notice() {
 	if (!current_user_can('manage_options')) {
 		return;
 	}
-	
+
 	$se_meta = se_get_meta();
 
 	$close_url = admin_url( 'options-general.php' );
@@ -86,7 +86,7 @@ function se_global_notice() {
 	), $close_url );
 
 	$notice = $se_meta['se_global_notice'];
-	
+
 	if ($notice && in_array($pagenow, $se_global_notice_pages)) {
 		include(se_get_view('global_notice'));
 	}
@@ -103,7 +103,7 @@ class SearchEverything {
 	var $ajax_request;
 	private $query_instance;
 
-	function SearchEverything($ajax_query=false) {
+	function __construct($ajax_query=false) {
 		global $wp_version;
 		$this->wp_ver23 = ( $wp_version >= '2.3' );
 		$this->wp_ver25 = ( $wp_version >= '2.5' );
@@ -116,7 +116,7 @@ class SearchEverything {
 		}
 		else {
 			$this->init();
-		}		
+		}
 	}
 
 	function init_ajax($query) {
@@ -146,7 +146,7 @@ class SearchEverything {
 
 	function search_hooks() {
 		//add filters based upon option settings
-		
+
 		if ( $this->options['se_use_tag_search'] || $this->options['se_use_category_search'] || $this->options['se_use_tax_search'] ) {
 			add_filter( 'posts_join', array( &$this, 'se_terms_join' ) );
 			if ( $this->options['se_use_tag_search'] ) {
@@ -288,7 +288,7 @@ class SearchEverything {
 	// search for terms in default locations like title and content
 	// replacing the old search terms seems to be the best way to
 	// avoid issue with multiple terms
-	function se_search_default(){ 
+	function se_search_default(){
 
 		global $wpdb;
 
@@ -309,7 +309,7 @@ class SearchEverything {
 
 			$like_title = "($wpdb->posts.post_title LIKE '$esc_term')";
 			$like_post = "($wpdb->posts.post_content LIKE '$esc_term')";
-			
+
 			$search_sql_query .= "($like_title OR $like_post)";
 
 			$seperator = ' AND ';
@@ -391,7 +391,7 @@ class SearchEverything {
 	function se_build_search_excerpt() {
 		global $wpdb;
 		$vars = $this->query_instance->query_vars;
-		
+
 		$s = $vars['s'];
 		$search_terms = $this->se_get_search_terms();
 		$exact = isset( $vars['exact'] ) ? $vars['exact'] : '';
@@ -457,7 +457,7 @@ class SearchEverything {
 	function se_build_search_comments() {
 		global $wpdb;
 		$vars = $this->query_instance->query_vars;
-		
+
 		$s = $vars['s'];
 		$search_terms = $this->se_get_search_terms();
 		$exact = isset( $vars['exact'] ) ? $vars['exact'] : '';
@@ -627,7 +627,7 @@ class SearchEverything {
 	function se_build_search_categories() {
 		global $wpdb;
 		$vars = $this->query_instance->query_vars;
-		
+
 		$s = $vars['s'];
 		$search_terms = $this->se_get_search_terms();
 		$exact = isset( $vars['exact'] ) ? $vars['exact'] : '';
@@ -884,7 +884,7 @@ function search_everything_callback() {
 			$result['external'] = json_decode($zemanta_response['body'])->articles;
 		}
 
-		
+
 		$SE = new SearchEverything(true);
 
 		if (!empty($_GET['exact'])) {
@@ -899,7 +899,7 @@ function search_everything_callback() {
 			$result['own'][] = get_post();
 		}
 		$post_query->reset_postdata();
-		
+
 	}
 	print json_encode($result);
 	die();


### PR DESCRIPTION
* Update classes from PHP4 constructors to PHP5+ __construct(), which
makes the plugin PHP7 compatible without throwing deprecated error
messages.  See this:
https://make.wordpress.org/core/2015/07/02/deprecating-php4-style-constructors-in-wordpress-4-3/
* Also removed whitespaces